### PR TITLE
管理者アカウント作成後のログイン不要バグの修正

### DIFF
--- a/src/main/java/jp/co/sample/emp_management/controller/AdministratorController.java
+++ b/src/main/java/jp/co/sample/emp_management/controller/AdministratorController.java
@@ -77,7 +77,7 @@ public class AdministratorController {
 		// フォームからドメインにプロパティ値をコピー
 		BeanUtils.copyProperties(form, administrator);
 		administratorService.insert(administrator);
-		return "employee/list";
+		return "redirect:/";
 	}
 
 	/////////////////////////////////////////////////////


### PR DESCRIPTION
管理者アカウント作成後に、ログイン画面ではなく従業員一覧画面に画面遷移してしまうバグを修正しました。
レビューをお願いします。

